### PR TITLE
Add `botocore` as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "requests>=2.23.0",
         "monty>=2021.3.12",
         "emmet-core>=0.54.0",
+        "botocore",
     ],
     extras_require={
         "all": ["emmet-core[all]>=0.54.0", "custodian", "mpcontribs-client", "boto3"],


### PR DESCRIPTION
Our GitHub actions tests for [PyTASER](https://pytaser.readthedocs.io/en/latest/) were still failing following the recent update to make `boto3` an optional dependency, and this seems to be because `botocore` is required by `mp-api` but is not a listed dependency.
This was the error output:
```
Run pytest tests/test_generator.py  # test generator
ImportError while loading conftest '/home/runner/work/PyTASER/PyTASER/tests/conftest.py'.
tests/conftest.py:6: in <module>
    from pytaser.generator import TASGenerator
pytaser/generator.py:7: in <module>
    from pymatgen.ext.matproj import MPRester
/opt/hostedtoolcache/Python/3.8.[17](https://github.com/WMD-group/PyTASER/actions/runs/5877703627/job/15938311045?pr=49#step:6:18)/x64/lib/python3.8/site-packages/pymatgen/ext/matproj.py:28: in <module>
    from mp_api.client import MPRester as _MPResterNew
/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/mp_api/client/__init__.py:5: in <module>
    from .core import MPRestError
/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/mp_api/client/core/__init__.py:1: in <module>
    from .client import BaseRester, MPRestError
/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/mp_api/client/core/client.py:[21](https://github.com/WMD-group/PyTASER/actions/runs/5877703627/job/15938311045?pr=49#step:6:22): in <module>
    from botocore import UNSIGNED
E   ModuleNotFoundError: No module named 'botocore'
```

If you need more info, the packages GitHub actions installed were:
```
Successfully installed PyYAML-6.0.1 certifi-2023.7.22 charset-normalizer-3.2.0 contourpy-1.1.0 cycler-0.11.0 emmet-core-0.64.4 fonttools-4.42.0 future-0.18.3 idna-3.4 importlib-resources-6.0.1 joblib-1.3.2 kiwisolver-1.4.4 latexcodec-2.0.1 matplotlib-3.7.2 monty-2023.8.8 mp-api-0.34.1 mpmath-1.3.0 msgpack-1.0.5 networkx-3.1 palettable-3.3.3 pandas-2.0.3 pillow-10.0.0 plotly-5.16.0 pybtex-0.24.0 pydantic-1.10.12 pymatgen-2023.8.10 pyparsing-3.0.9 pytaser-2.1.0 python-dateutil-2.8.2 pytz-2023.3 requests-2.31.0 ruamel.yaml-0.17.32 ruamel.yaml.clib-0.2.7 scipy-1.10.1 six-1.16.0 spglib-2.0.2 sympy-1.12 tabulate-0.9.0 tenacity-8.2.3 tqdm-4.66.1 tzdata-2023.3 uncertainties-3.1.7 urllib3-2.0.4 zipp-3.16.2
```
and the log archive is attached: [logs_198.zip](https://github.com/kavanase/api/files/12358477/logs_198.zip)

This PR adds `botocore` as a dependency in `setup.py`